### PR TITLE
fix(metrics): reconcile profiles_managed gauge

### DIFF
--- a/charts/kapparmor/CHANGELOG.md
+++ b/charts/kapparmor/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.1] - 2025-11
 
+### Changed
+
+- **Managed Profiles Gauge Fix**: `kapparmor_profiles_managed` now reconciles from the post-sync managed profile state, so already-loaded unchanged profiles are counted correctly without double-counting modified profiles.
+
 ### Added
 
 - **Prometheus Metrics Integration**: Complete metrics package enabling observability

--- a/charts/kapparmor/CHANGELOG.md
+++ b/charts/kapparmor/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Managed Profiles Gauge Fix**: `kapparmor_profiles_managed` now reconciles from the post-sync managed profile state, so already-loaded unchanged profiles are counted correctly without double-counting modified profiles.
+- **Profile Operations Counter Semantics**: `kapparmor_profile_operations_total{operation="create"}` now increments only after a successful first-time profile load, while modified profiles increment `operation="modify"` only after a successful replace.
 
 ### Added
 

--- a/src/app/main.go
+++ b/src/app/main.go
@@ -208,7 +208,7 @@ func loadNewProfiles(cfg *AppConfig) ([]string, error) {
 	printLogSeparator()
 
 	if err := publishManagedProfileCount(cfg, newProfiles); err != nil {
-		applyErrors = append(applyErrors, err)
+		slog.Default().Warn("failed to publish managed profile gauge", slog.Any("error", err))
 	}
 
 	if len(applyErrors) > 0 {
@@ -276,6 +276,14 @@ func loadProfile(cfg *AppConfig, profilePath string) error {
 	slog.Default().Info("Copying profile", slog.String("dest", cfg.EtcApparmord))
 
 	if err := CopyFile(profilePath, cfg.EtcApparmord); err != nil {
+		// Keep kernel and persisted state aligned so later cleanup and metrics stay reliable.
+		if rollbackErr := execApparmor(cfg, "--verbose", "--remove", profilePath); rollbackErr != nil {
+			return fmt.Errorf(
+				"failed to copy profile to destination and rollback kernel state: %w",
+				errors.Join(err, rollbackErr),
+			)
+		}
+
 		return fmt.Errorf("failed to copy profile to destination: %w", err)
 	}
 

--- a/src/app/main.go
+++ b/src/app/main.go
@@ -101,9 +101,8 @@ func RunApp(parentCtx context.Context, cfg *AppConfig) error {
 	if err := unloadAllProfiles(cfg); err != nil {
 		cfg.Logger.Error("failed to unload all profiles during shutdown", slog.Any("error", err))
 		// Don't return error - attempt best-effort cleanup
-	} else {
-		metrics.SetProfileCount(0)
 	}
+	metrics.SetProfileCount(0)
 
 	cfg.Logger.Info("The eagle has landed. Over and out.")
 
@@ -220,6 +219,10 @@ func loadNewProfiles(cfg *AppConfig) ([]string, error) {
 }
 
 func applyProfiles(cfg *AppConfig, profilePaths []string, customLoadedProfiles map[string]bool) []error {
+	if len(profilePaths) == 0 {
+		return nil
+	}
+
 	printLogSeparator()
 	slog.Default().Info("Apparmor REPLACE and apply new profiles..")
 
@@ -237,6 +240,8 @@ func applyProfiles(cfg *AppConfig, profilePaths []string, customLoadedProfiles m
 
 		if isNewProfile {
 			metrics.ProfileCreated(profileName)
+		} else {
+			metrics.ProfileModified(profileName)
 		}
 	}
 
@@ -278,13 +283,20 @@ func loadProfile(cfg *AppConfig, profilePath string) error {
 }
 
 func publishManagedProfileCount(cfg *AppConfig, desiredProfiles map[string]bool) error {
+	// Refresh kernel state after apply/remove so the gauge reflects authoritative post-sync state.
 	_, customLoadedProfiles, err := getLoadedProfiles(cfg)
 	if err != nil {
 		return fmt.Errorf("error refreshing existing profiles for metrics: %w", err)
 	}
 
 	delete(customLoadedProfiles, "")
-	metrics.SetProfileCount(countManagedProfiles(desiredProfiles, customLoadedProfiles))
+	managedProfiles := countManagedProfiles(desiredProfiles, customLoadedProfiles)
+	slog.Default().Debug("publishing managed profile gauge",
+		slog.Int("desired_profiles", len(desiredProfiles)),
+		slog.Int("loaded_custom_profiles", len(customLoadedProfiles)),
+		slog.Int("managed_profiles", managedProfiles),
+	)
+	metrics.SetProfileCount(managedProfiles)
 
 	return nil
 }

--- a/src/app/main.go
+++ b/src/app/main.go
@@ -101,6 +101,8 @@ func RunApp(parentCtx context.Context, cfg *AppConfig) error {
 	if err := unloadAllProfiles(cfg); err != nil {
 		cfg.Logger.Error("failed to unload all profiles during shutdown", slog.Any("error", err))
 		// Don't return error - attempt best-effort cleanup
+	} else {
+		metrics.SetProfileCount(0)
 	}
 
 	cfg.Logger.Info("The eagle has landed. Over and out.")
@@ -198,39 +200,66 @@ func loadNewProfiles(cfg *AppConfig) ([]string, error) {
 	}
 
 	// 4. Execute apparmor_parser --replace
-	printLogSeparator()
-	slog.Default().Info("Apparmor REPLACE and apply new profiles..")
-
-	// Collect errors.
-	var applyErrors []error
-	for _, profilePath := range newProfilesToApply {
-		if err := loadProfile(cfg, profilePath); err != nil {
-			slog.Default().Error("apply profile error", slog.Any("error", err))
-			applyErrors = append(applyErrors, err)
-		}
-	}
+	applyErrors := applyProfiles(cfg, newProfilesToApply, customLoadedProfiles)
 
 	// 5. Execute apparmor_parser --remove
-	if len(loadedProfilesToUnload) > 0 {
-		printLogSeparator()
-		slog.Default().Info("AppArmor REMOVE orphans profiles..")
-
-		for _, profileFileName := range loadedProfilesToUnload {
-			if err := unloadProfile(cfg, profileFileName); err != nil {
-				slog.Default().Error("remove orphan profile error", slog.Any("error", err))
-				applyErrors = append(applyErrors, err)
-			}
-		}
-	}
+	applyErrors = append(applyErrors, unloadProfiles(cfg, loadedProfilesToUnload)...)
 
 	slog.Default().Info("> Done! > Waiting next poll..")
 	printLogSeparator()
+
+	if err := publishManagedProfileCount(cfg, newProfiles); err != nil {
+		applyErrors = append(applyErrors, err)
+	}
 
 	if len(applyErrors) > 0 {
 		return newProfilesToApply, fmt.Errorf("encountered %d errors during profile operations", len(applyErrors))
 	}
 
 	return newProfilesToApply, nil
+}
+
+func applyProfiles(cfg *AppConfig, profilePaths []string, customLoadedProfiles map[string]bool) []error {
+	printLogSeparator()
+	slog.Default().Info("Apparmor REPLACE and apply new profiles..")
+
+	var applyErrors []error
+	for _, profilePath := range profilePaths {
+		profileName := path.Base(profilePath)
+		isNewProfile := !customLoadedProfiles[profileName]
+
+		if err := loadProfile(cfg, profilePath); err != nil {
+			slog.Default().Error("apply profile error", slog.Any("error", err))
+			applyErrors = append(applyErrors, err)
+
+			continue
+		}
+
+		if isNewProfile {
+			metrics.ProfileCreated(profileName)
+		}
+	}
+
+	return applyErrors
+}
+
+func unloadProfiles(cfg *AppConfig, profileNames []string) []error {
+	if len(profileNames) == 0 {
+		return nil
+	}
+
+	printLogSeparator()
+	slog.Default().Info("AppArmor REMOVE orphans profiles..")
+
+	var unloadErrors []error
+	for _, profileFileName := range profileNames {
+		if err := unloadProfile(cfg, profileFileName); err != nil {
+			slog.Default().Error("remove orphan profile error", slog.Any("error", err))
+			unloadErrors = append(unloadErrors, err)
+		}
+	}
+
+	return unloadErrors
 }
 
 // Load an apparmor profile into the kernel.
@@ -245,11 +274,31 @@ func loadProfile(cfg *AppConfig, profilePath string) error {
 		return fmt.Errorf("failed to copy profile to destination: %w", err)
 	}
 
-	// Extract profile name from path for metrics
-	profileName := path.Base(profilePath)
-	metrics.ProfileCreated(profileName)
+	return nil
+}
+
+func publishManagedProfileCount(cfg *AppConfig, desiredProfiles map[string]bool) error {
+	_, customLoadedProfiles, err := getLoadedProfiles(cfg)
+	if err != nil {
+		return fmt.Errorf("error refreshing existing profiles for metrics: %w", err)
+	}
+
+	delete(customLoadedProfiles, "")
+	metrics.SetProfileCount(countManagedProfiles(desiredProfiles, customLoadedProfiles))
 
 	return nil
+}
+
+func countManagedProfiles(desiredProfiles, customLoadedProfiles map[string]bool) int {
+	managedProfiles := 0
+
+	for profileName := range desiredProfiles {
+		if customLoadedProfiles[profileName] {
+			managedProfiles++
+		}
+	}
+
+	return managedProfiles
 }
 
 // Remove all custom profiles from the kernel, reading from ETC_APPARMORD folder.

--- a/src/app/metrics/metrics.go
+++ b/src/app/metrics/metrics.go
@@ -44,16 +44,14 @@ func getNodeNameFromEnv() string {
 
 // Metrics setters
 
-// ProfileCreated increments create counter and increments gauge.
+// ProfileCreated increments the create counter.
 func ProfileCreated(p string) {
 	profileOperations.WithLabelValues("create", p).Inc()
-	currentProfiles.Inc()
 }
 
-// ProfileDeleted increments delete counter and decrements gauge.
+// ProfileDeleted increments the delete counter.
 func ProfileDeleted(p string) {
 	profileOperations.WithLabelValues("delete", p).Inc()
-	currentProfiles.Dec()
 }
 
 // ProfileModified is an alias used by tests for updates.

--- a/src/app/metrics/metrics.go
+++ b/src/app/metrics/metrics.go
@@ -54,7 +54,7 @@ func ProfileDeleted(p string) {
 	profileOperations.WithLabelValues("delete", p).Inc()
 }
 
-// ProfileModified is an alias used by tests for updates.
+// ProfileModified increments the modify counter.
 func ProfileModified(p string) {
 	profileOperations.WithLabelValues("modify", p).Inc()
 }

--- a/src/app/metrics/t_metrics_test.go
+++ b/src/app/metrics/t_metrics_test.go
@@ -114,6 +114,25 @@ func TestSetProfileCount(t *testing.T) {
 	}
 }
 
+func TestProfileOperationsDoNotChangeManagedGauge(t *testing.T) {
+	resetMetrics()
+	testNodeName := getNodeNameFromEnv()
+
+	SetProfileCount(7)
+	ProfileCreated("profilo-a")
+	ProfileModified("profilo-b")
+	ProfileDeleted("profilo-c")
+
+	expected := `
+		# HELP kapparmor_profiles_managed Numero totale di profili AppArmor attualmente gestiti.
+		# TYPE kapparmor_profiles_managed gauge
+		kapparmor_profiles_managed{node_name="` + testNodeName + `"} 7
+	`
+	if err := testutil.CollectAndCompare(currentProfiles, strings.NewReader(expected), "kapparmor_profiles_managed"); err != nil {
+		t.Errorf("Metrica kapparmor_profiles_managed non corrispondente: %v", err)
+	}
+}
+
 func TestGetNodeNameFromEnv(t *testing.T) {
 	// 1. Test con NODE_NAME impostato
 	t.Setenv("NODE_NAME", "test-nodo-123")

--- a/src/app/profiles_ops.go
+++ b/src/app/profiles_ops.go
@@ -11,8 +11,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-
-	"github.com/tuxerrante/kapparmor/src/app/metrics"
 )
 
 // printLoadedProfiles prints node apparmor loaded profiles.
@@ -116,7 +114,6 @@ func calculateProfileChanges(cfg *AppConfig, newProfiles map[string]bool, custom
 			}
 			slog.Default().Info("Content changed, scheduling replacement", slog.String("name", newProfileName))
 			showProfilesDiff(cfg, newProfileName)
-			metrics.ProfileModified(newProfileName)
 		} else {
 			slog.Default().Info("New profile found, scheduling for load", slog.String("name", newProfileName))
 		}

--- a/src/app/t_load_new_profiles_metrics_test.go
+++ b/src/app/t_load_new_profiles_metrics_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/tuxerrante/kapparmor/src/app/metrics"
+)
+
+func writeProfileFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatalf("write profile %s: %v", name, err)
+	}
+}
+
+func writeKernelProfiles(t *testing.T, kernelPath string, names ...string) {
+	t.Helper()
+
+	var builder strings.Builder
+	for _, name := range names {
+		builder.WriteString(name)
+		builder.WriteString(" (enforce)\n")
+	}
+
+	if err := os.WriteFile(kernelPath, []byte(builder.String()), 0o600); err != nil {
+		t.Fatalf("write kernel profiles: %v", err)
+	}
+}
+
+func writeKernelUpdatingParser(t *testing.T, cfg *AppConfig, failingProfiles ...string) string {
+	t.Helper()
+
+	var failCases strings.Builder
+	for _, profile := range failingProfiles {
+		failCases.WriteString("\t\t")
+		failCases.WriteString(profile)
+		failCases.WriteString(")\n")
+		failCases.WriteString("\t\t\techo 'ERR: simulated failure' 1>&2\n")
+		failCases.WriteString("\t\t\texit 1\n")
+		failCases.WriteString("\t\t\t;;\n")
+	}
+	failCases.WriteString("\t\t*) ;;\n")
+
+	scriptPath := filepath.Join(filepath.Dir(cfg.ProfilerFullPath), "apparmor_parser")
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+
+kernel=%q
+last_arg=""
+for arg in "$@"; do
+	last_arg="$arg"
+done
+
+name=$(basename "$last_arg")
+line="$name (enforce)"
+tmp="$kernel.tmp"
+
+case " $* " in
+  *" --replace "*)
+    case "$name" in
+%s
+    esac
+    if [ -f "$kernel" ]; then
+      awk -v name="$name" '$1 != name { print }' "$kernel" > "$tmp"
+    else
+      : > "$tmp"
+    fi
+    printf '%%s\n' "$line" >> "$tmp"
+    mv "$tmp" "$kernel"
+    echo 'OK: simulated load'
+    ;;
+  *" --remove "*)
+    if [ -f "$kernel" ]; then
+      awk -v name="$name" '$1 != name { print }' "$kernel" > "$tmp"
+      mv "$tmp" "$kernel"
+    fi
+    echo 'OK: simulated remove'
+    ;;
+  *" --reload "*)
+    echo 'OK: simulated reload'
+    ;;
+  *)
+    echo 'OK: simulated noop'
+    ;;
+esac
+`, cfg.KernelPath, failCases.String())
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("write parser script: %v", err)
+	}
+
+	return scriptPath
+}
+
+func managedProfilesGaugeValue(t *testing.T) float64 {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != "kapparmor_profiles_managed" {
+			continue
+		}
+		if len(family.GetMetric()) != 1 {
+			t.Fatalf("expected one managed profile gauge, got %d", len(family.GetMetric()))
+		}
+
+		return family.GetMetric()[0].GetGauge().GetValue()
+	}
+
+	t.Fatal("kapparmor_profiles_managed gauge not found")
+
+	return 0
+}
+
+func profileOperationCounterValue(t *testing.T, operation, profileName string) float64 {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != "kapparmor_profile_operations_total" {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			var gotOperation, gotProfileName string
+			for _, label := range metric.GetLabel() {
+				switch label.GetName() {
+				case "operation":
+					gotOperation = label.GetValue()
+				case "profile_name":
+					gotProfileName = label.GetValue()
+				}
+			}
+
+			if gotOperation == operation && gotProfileName == profileName {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+
+	return 0
+}
+
+func TestLoadNewProfilesCountsAlreadyLoadedProfiles(t *testing.T) {
+	cfg, _ := preFlightChecksInit(t)
+	cfg.ProfilerFullPath = writeKernelUpdatingParser(t, cfg)
+	testOpenProfileRoots(t, cfg)
+
+	const profileName = "custom.metricsunchanged"
+	content := "profile custom.metricsunchanged { }\n"
+	writeProfileFile(t, cfg.ConfigmapPath, profileName, content)
+	writeProfileFile(t, cfg.EtcApparmord, profileName, content)
+	writeKernelProfiles(t, cfg.KernelPath, profileName)
+	metrics.SetProfileCount(0)
+
+	if _, err := loadNewProfiles(cfg); err != nil {
+		t.Fatalf("loadNewProfiles: %v", err)
+	}
+
+	if got := managedProfilesGaugeValue(t); got != 1 {
+		t.Fatalf("expected managed gauge to be 1, got %.0f", got)
+	}
+
+	if got := profileOperationCounterValue(t, "create", profileName); got != 0 {
+		t.Fatalf("expected create counter to stay at 0, got %.0f", got)
+	}
+}
+
+func TestLoadNewProfilesDoesNotCountModifiedProfilesAsCreate(t *testing.T) {
+	cfg, _ := preFlightChecksInit(t)
+	cfg.ProfilerFullPath = writeKernelUpdatingParser(t, cfg)
+	testOpenProfileRoots(t, cfg)
+
+	const profileName = "custom.metricsmodified"
+	writeProfileFile(t, cfg.ConfigmapPath, profileName, "profile custom.metricsmodified { # desired }\n")
+	writeProfileFile(t, cfg.EtcApparmord, profileName, "profile custom.metricsmodified { # current }\n")
+	writeKernelProfiles(t, cfg.KernelPath, profileName)
+	metrics.SetProfileCount(0)
+
+	if _, err := loadNewProfiles(cfg); err != nil {
+		t.Fatalf("loadNewProfiles: %v", err)
+	}
+
+	if got := managedProfilesGaugeValue(t); got != 1 {
+		t.Fatalf("expected managed gauge to stay at 1, got %.0f", got)
+	}
+
+	if got := profileOperationCounterValue(t, "modify", profileName); got != 1 {
+		t.Fatalf("expected modify counter to be 1, got %.0f", got)
+	}
+
+	if got := profileOperationCounterValue(t, "create", profileName); got != 0 {
+		t.Fatalf("expected create counter to stay at 0 for modified profile, got %.0f", got)
+	}
+}
+
+func TestLoadNewProfilesUpdatesGaugeAfterDeletingOrphans(t *testing.T) {
+	cfg, _ := preFlightChecksInit(t)
+	cfg.ProfilerFullPath = writeKernelUpdatingParser(t, cfg)
+	testOpenProfileRoots(t, cfg)
+
+	const keepProfile = "custom.metricskeep"
+	const deleteProfile = "custom.metricsdelete"
+	content := "profile %s { }\n"
+	writeProfileFile(t, cfg.ConfigmapPath, keepProfile, fmt.Sprintf(content, keepProfile))
+	writeProfileFile(t, cfg.EtcApparmord, keepProfile, fmt.Sprintf(content, keepProfile))
+	writeProfileFile(t, cfg.EtcApparmord, deleteProfile, fmt.Sprintf(content, deleteProfile))
+	writeKernelProfiles(t, cfg.KernelPath, keepProfile, deleteProfile)
+	metrics.SetProfileCount(0)
+
+	if _, err := loadNewProfiles(cfg); err != nil {
+		t.Fatalf("loadNewProfiles: %v", err)
+	}
+
+	if got := managedProfilesGaugeValue(t); got != 1 {
+		t.Fatalf("expected managed gauge to be 1 after deleting orphan, got %.0f", got)
+	}
+
+	if got := profileOperationCounterValue(t, "delete", deleteProfile); got != 1 {
+		t.Fatalf("expected delete counter to be 1, got %.0f", got)
+	}
+}
+
+func TestLoadNewProfilesPublishesGaugeAfterPartialFailure(t *testing.T) {
+	cfg, _ := preFlightChecksInit(t)
+	cfg.ProfilerFullPath = writeKernelUpdatingParser(t, cfg, "custom.metricsfail")
+	testOpenProfileRoots(t, cfg)
+
+	const okProfile = "custom.metricsok"
+	const failProfile = "custom.metricsfail"
+	writeProfileFile(t, cfg.ConfigmapPath, okProfile, "profile custom.metricsok { }\n")
+	writeProfileFile(t, cfg.ConfigmapPath, failProfile, "profile custom.metricsfail { }\n")
+	writeKernelProfiles(t, cfg.KernelPath)
+	metrics.SetProfileCount(0)
+
+	if _, err := loadNewProfiles(cfg); err == nil {
+		t.Fatal("expected loadNewProfiles to report partial failure")
+	}
+
+	if got := managedProfilesGaugeValue(t); got != 1 {
+		t.Fatalf("expected managed gauge to count only successful loads, got %.0f", got)
+	}
+
+	if got := profileOperationCounterValue(t, "create", okProfile); got != 1 {
+		t.Fatalf("expected create counter for successful profile to be 1, got %.0f", got)
+	}
+
+	if got := profileOperationCounterValue(t, "create", failProfile); got != 0 {
+		t.Fatalf("expected create counter for failed profile to stay at 0, got %.0f", got)
+	}
+}

--- a/src/app/t_load_new_profiles_metrics_test.go
+++ b/src/app/t_load_new_profiles_metrics_test.go
@@ -264,3 +264,73 @@ func TestLoadNewProfilesPublishesGaugeAfterPartialFailure(t *testing.T) {
 		t.Fatalf("expected create counter for failed profile to stay at 0, got %.0f", got)
 	}
 }
+
+func TestLoadNewProfilesIgnoresManagedGaugePublishFailure(t *testing.T) {
+	cfg, _ := preFlightChecksInit(t)
+	cfg.ProfilerFullPath = writeKernelUpdatingParser(t, cfg)
+
+	const orphanProfile = "custom.metricsorphan"
+	if err := os.WriteFile(filepath.Join(cfg.ConfigmapPath, ".ignored"), []byte("ignored"), 0o600); err != nil {
+		t.Fatalf("write hidden file: %v", err)
+	}
+
+	// Point the kernel profile list at the same file that orphan cleanup removes so
+	// publishManagedProfileCount fails only after the unload work has completed.
+	cfg.KernelPath = filepath.Join(cfg.EtcApparmord, orphanProfile)
+	writeKernelProfiles(t, cfg.KernelPath, orphanProfile)
+	metrics.SetProfileCount(9)
+
+	appliedProfiles, err := loadNewProfiles(cfg)
+	if err != nil {
+		t.Fatalf("loadNewProfiles should ignore managed gauge publish failures: %v", err)
+	}
+
+	if len(appliedProfiles) != 0 {
+		t.Fatalf("expected no profiles to apply, got %v", appliedProfiles)
+	}
+
+	if got := managedProfilesGaugeValue(t); got != 9 {
+		t.Fatalf("expected managed gauge to stay at the last published value, got %.0f", got)
+	}
+
+	if got := profileOperationCounterValue(t, "delete", orphanProfile); got != 1 {
+		t.Fatalf("expected delete counter to be 1, got %.0f", got)
+	}
+
+	if _, err := os.Stat(filepath.Join(cfg.EtcApparmord, orphanProfile)); !os.IsNotExist(err) {
+		t.Fatalf("expected orphan profile to be removed from disk, got err=%v", err)
+	}
+}
+
+func TestLoadProfileRollsBackKernelLoadWhenCopyFails(t *testing.T) {
+	cfg, _ := preFlightChecksInit(t)
+	cfg.ProfilerFullPath = writeKernelUpdatingParser(t, cfg)
+
+	const profileName = "custom.metricsrollback"
+	profilePath := filepath.Join(cfg.ConfigmapPath, profileName)
+	writeProfileFile(t, cfg.ConfigmapPath, profileName, fmt.Sprintf("profile %s { }\n", profileName))
+
+	badDestination := filepath.Join(filepath.Dir(cfg.EtcApparmord), "not-a-directory")
+	if err := os.WriteFile(badDestination, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write bad destination marker: %v", err)
+	}
+	cfg.EtcApparmord = badDestination
+
+	err := loadProfile(cfg, profilePath)
+	if err == nil {
+		t.Fatal("expected loadProfile to fail when profile persistence fails")
+	}
+
+	if !strings.Contains(err.Error(), "failed to copy profile to destination") {
+		t.Fatalf("expected copy failure error, got %v", err)
+	}
+
+	_, customLoadedProfiles, err := getLoadedProfiles(cfg)
+	if err != nil {
+		t.Fatalf("getLoadedProfiles: %v", err)
+	}
+
+	if customLoadedProfiles[profileName] {
+		t.Fatalf("expected %s to be removed from kernel after rollback", profileName)
+	}
+}


### PR DESCRIPTION
## Summary
- make the reconcile path the single owner of `kapparmor_profiles_managed`
- keep `create` and `delete` as event counters while publishing the managed-profile gauge from post-sync state
- add regression coverage for unchanged, modified, deleted, and partial-failure metric flows, and note the user-visible metric fix in the chart changelog

## Test plan
- [x] `make fmt`
- [x] `make vet lint test-coverage`
- [x] `go test -v -run 'TestLoadNewProfiles|TestProfileOperationsDoNotChangeManagedGauge|TestSetProfileCount|TestProfileOperations' ./src/app/...`
- [ ] `make e2e-case3` (not run locally)

## Notes
- This replaces the closed attempt from #81 with a smaller correctness-only PR.
- The managed-profile gauge now reflects the desired custom profiles actually loaded after reconciliation, including already-loaded unchanged profiles, without double-counting modified profiles.