### PR TITLE
refactor(metrics): centralize profile metric ownership

### DIFF
--- a/src/app/main.go
+++ b/src/app/main.go
@@ -102,7 +102,7 @@ func RunApp(parentCtx context.Context, cfg *AppConfig) error {
 		cfg.Logger.Error("failed to unload all profiles during shutdown", slog.Any("error", err))
 		// Don't return error - attempt best-effort cleanup
 	} else {
-		metrics.SetProfileCount(0)
+		metrics.DefaultProfileMetrics().SetManagedProfiles(0)
 	}
 
 	cfg.Logger.Info("The eagle has landed. Over and out.")
@@ -223,6 +223,7 @@ func applyProfiles(cfg *AppConfig, profilePaths []string, customLoadedProfiles m
 	printLogSeparator()
 	slog.Default().Info("Apparmor REPLACE and apply new profiles..")
 
+	metricsOwner := metrics.DefaultProfileMetrics()
 	var applyErrors []error
 	for _, profilePath := range profilePaths {
 		profileName := path.Base(profilePath)
@@ -236,7 +237,7 @@ func applyProfiles(cfg *AppConfig, profilePaths []string, customLoadedProfiles m
 		}
 
 		if isNewProfile {
-			metrics.ProfileCreated(profileName)
+			metricsOwner.ProfileCreated(profileName)
 		}
 	}
 
@@ -284,7 +285,7 @@ func publishManagedProfileCount(cfg *AppConfig, desiredProfiles map[string]bool)
 	}
 
 	delete(customLoadedProfiles, "")
-	metrics.SetProfileCount(countManagedProfiles(desiredProfiles, customLoadedProfiles))
+	metrics.DefaultProfileMetrics().SetManagedProfiles(countManagedProfiles(desiredProfiles, customLoadedProfiles))
 
 	return nil
 }
@@ -418,7 +419,7 @@ func unloadProfile(cfg *AppConfig, fileName string) error {
 
 	// Extract profile name from path for metrics
 	profileName := path.Base(fileName)
-	metrics.ProfileDeleted(profileName)
+	metrics.DefaultProfileMetrics().ProfileDeleted(profileName)
 
 	return nil
 }

--- a/src/app/metrics/metrics.go
+++ b/src/app/metrics/metrics.go
@@ -9,27 +9,44 @@ import (
 )
 
 var (
-	nodeName = getNodeNameFromEnv()
+	nodeName             = getNodeNameFromEnv()
+	defaultProfileMetric = newProfileMetrics()
 
-	// profileOperations counts create/modify/delete operations per profile.
-	profileOperations = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace:   "kapparmor",
-			Name:        "profile_operations_total",
-			Help:        "Numero totale di operazioni sui profili (create, modify, delete).",
-			ConstLabels: prometheus.Labels{"node_name": nodeName},
-		},
-		[]string{"operation", "profile_name"},
-	)
-
-	// currentProfiles tracks how many profiles are currently managed.
-	currentProfiles = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace:   "kapparmor",
-		Name:        "profiles_managed",
-		Help:        "Numero totale di profili AppArmor attualmente gestiti.",
-		ConstLabels: prometheus.Labels{"node_name": nodeName},
-	})
+	// These aliases keep the existing test helpers and package-level API intact.
+	profileOperations = defaultProfileMetric.profileOperations
+	currentProfiles   = defaultProfileMetric.managedProfiles
 )
+
+// ProfileMetrics owns the Prometheus counters and gauges published by the app.
+type ProfileMetrics struct {
+	profileOperations *prometheus.CounterVec
+	managedProfiles   prometheus.Gauge
+}
+
+func newProfileMetrics() *ProfileMetrics {
+	return &ProfileMetrics{
+		profileOperations: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   "kapparmor",
+				Name:        "profile_operations_total",
+				Help:        "Total number of profile operations (create, modify, delete).",
+				ConstLabels: prometheus.Labels{"node_name": nodeName},
+			},
+			[]string{"operation", "profile_name"},
+		),
+		managedProfiles: promauto.NewGauge(prometheus.GaugeOpts{
+			Namespace:   "kapparmor",
+			Name:        "profiles_managed",
+			Help:        "Total number of AppArmor profiles currently managed.",
+			ConstLabels: prometheus.Labels{"node_name": nodeName},
+		}),
+	}
+}
+
+// DefaultProfileMetrics returns the process-wide metrics owner.
+func DefaultProfileMetrics() *ProfileMetrics {
+	return defaultProfileMetric
+}
 
 func getNodeNameFromEnv() string {
 	if n := os.Getenv("NODE_NAME"); n != "" {
@@ -46,17 +63,17 @@ func getNodeNameFromEnv() string {
 
 // ProfileCreated increments the create counter.
 func ProfileCreated(p string) {
-	profileOperations.WithLabelValues("create", p).Inc()
+	DefaultProfileMetrics().ProfileCreated(p)
 }
 
 // ProfileDeleted increments the delete counter.
 func ProfileDeleted(p string) {
-	profileOperations.WithLabelValues("delete", p).Inc()
+	DefaultProfileMetrics().ProfileDeleted(p)
 }
 
 // ProfileModified is an alias used by tests for updates.
 func ProfileModified(p string) {
-	profileOperations.WithLabelValues("modify", p).Inc()
+	DefaultProfileMetrics().ProfileModified(p)
 }
 
 // ProfileUpdated kept for compatibility.
@@ -66,5 +83,25 @@ func ProfileUpdated(p string) {
 
 // SetProfileCount sets the gauge to c.
 func SetProfileCount(c int) {
-	currentProfiles.Set(float64(c))
+	DefaultProfileMetrics().SetManagedProfiles(c)
+}
+
+// ProfileCreated increments the create counter.
+func (m *ProfileMetrics) ProfileCreated(p string) {
+	m.profileOperations.WithLabelValues("create", p).Inc()
+}
+
+// ProfileDeleted increments the delete counter.
+func (m *ProfileMetrics) ProfileDeleted(p string) {
+	m.profileOperations.WithLabelValues("delete", p).Inc()
+}
+
+// ProfileModified increments the modify counter.
+func (m *ProfileMetrics) ProfileModified(p string) {
+	m.profileOperations.WithLabelValues("modify", p).Inc()
+}
+
+// SetManagedProfiles sets the managed-profile gauge.
+func (m *ProfileMetrics) SetManagedProfiles(c int) {
+	m.managedProfiles.Set(float64(c))
 }

--- a/src/app/metrics/t_metrics_test.go
+++ b/src/app/metrics/t_metrics_test.go
@@ -9,82 +9,64 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-// resetMetrics è una funzione di utilità per resettare le metriche globali tra i test.
-// Questo è necessario perché promauto registra metriche globali.
+// resetMetrics rebuilds the global metrics against a fresh default registry.
 func resetMetrics() {
 	// Create a fresh registry so we don't conflict with any previously registered metrics.
 	reg := prometheus.NewRegistry()
 	prometheus.DefaultRegisterer = reg
 	prometheus.DefaultGatherer = reg
 
-	// Assicura che nodeName sia resettato in base all'ambiente
+	// Re-read the node name from the current environment.
 	nodeName = getNodeNameFromEnv()
 
-	// Ricrea le metriche (promauto le registra automaticamente sul DefaultRegisterer, ora resettato)
-	profileOperations = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace:   "kapparmor",
-			Name:        "profile_operations_total",
-			Help:        "Numero totale di operazioni sui profili (create, modify, delete).",
-			ConstLabels: prometheus.Labels{"node_name": nodeName},
-		},
-		[]string{"operation", "profile_name"},
-	)
-
-	currentProfiles = promauto.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace:   "kapparmor",
-			Name:        "profiles_managed",
-			Help:        "Numero totale di profili AppArmor attualmente gestiti.",
-			ConstLabels: prometheus.Labels{"node_name": nodeName},
-		},
-	)
+	defaultProfileMetric = newProfileMetrics()
+	profileOperations = defaultProfileMetric.profileOperations
+	currentProfiles = defaultProfileMetric.managedProfiles
 }
 
 func TestProfileOperations(t *testing.T) {
 	resetMetrics()
-	testNodeName := getNodeNameFromEnv() // Ottieni il nome del nodo per il confronto
+	testNodeName := getNodeNameFromEnv()
 
-	// Test Creazione
-	ProfileCreated("profilo-a")
+	// Create operation
+	ProfileCreated("profile-a")
 	expectedCreate := `
-		# HELP kapparmor_profile_operations_total Numero totale di operazioni sui profili (create, modify, delete).
+		# HELP kapparmor_profile_operations_total Total number of profile operations (create, modify, delete).
 		# TYPE kapparmor_profile_operations_total counter
-		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="create",profile_name="profilo-a"} 1
+		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="create",profile_name="profile-a"} 1
 	`
 	if err := testutil.CollectAndCompare(profileOperations, strings.NewReader(expectedCreate), "kapparmor_profile_operations_total"); err != nil {
-		t.Errorf("Metrica ProfileCreated non corrispondente: %v", err)
+		t.Errorf("ProfileCreated metric mismatch: %v", err)
 	}
 
-	// Test Modifica (due volte)
-	ProfileModified("profilo-b")
-	ProfileModified("profilo-b")
+	// Modify operation (twice)
+	ProfileModified("profile-b")
+	ProfileModified("profile-b")
 	expectedModify := `
-		# HELP kapparmor_profile_operations_total Numero totale di operazioni sui profili (create, modify, delete).
+		# HELP kapparmor_profile_operations_total Total number of profile operations (create, modify, delete).
 		# TYPE kapparmor_profile_operations_total counter
-		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="create",profile_name="profilo-a"} 1
-		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="modify",profile_name="profilo-b"} 2
+		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="create",profile_name="profile-a"} 1
+		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="modify",profile_name="profile-b"} 2
 	`
 	if err := testutil.CollectAndCompare(profileOperations, strings.NewReader(expectedModify), "kapparmor_profile_operations_total"); err != nil {
-		t.Errorf("Metrica ProfileModified non corrispondente: %v", err)
+		t.Errorf("ProfileModified metric mismatch: %v", err)
 	}
 
-	// Test Eliminazione
-	ProfileDeleted("profilo-c")
+	// Delete operation
+	ProfileDeleted("profile-c")
 	expectedDelete := `
-		# HELP kapparmor_profile_operations_total Numero totale di operazioni sui profili (create, modify, delete).
+		# HELP kapparmor_profile_operations_total Total number of profile operations (create, modify, delete).
 		# TYPE kapparmor_profile_operations_total counter
-		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="create",profile_name="profilo-a"} 1
-		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="modify",profile_name="profilo-b"} 2
-		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="delete",profile_name="profilo-c"} 1
+		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="create",profile_name="profile-a"} 1
+		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="modify",profile_name="profile-b"} 2
+		kapparmor_profile_operations_total{node_name="` + testNodeName + `",operation="delete",profile_name="profile-c"} 1
 	`
 	if err := testutil.CollectAndCompare(profileOperations, strings.NewReader(expectedDelete), "kapparmor_profile_operations_total"); err != nil {
-		t.Errorf("Metrica ProfileDeleted non corrispondente: %v", err)
+		t.Errorf("ProfileDeleted metric mismatch: %v", err)
 	}
 }
 
@@ -94,23 +76,23 @@ func TestSetProfileCount(t *testing.T) {
 
 	SetProfileCount(42)
 	expected := `
-		# HELP kapparmor_profiles_managed Numero totale di profili AppArmor attualmente gestiti.
+		# HELP kapparmor_profiles_managed Total number of AppArmor profiles currently managed.
 		# TYPE kapparmor_profiles_managed gauge
 		kapparmor_profiles_managed{node_name="` + testNodeName + `"} 42
 	`
 	if err := testutil.CollectAndCompare(currentProfiles, strings.NewReader(expected), "kapparmor_profiles_managed"); err != nil {
-		t.Errorf("Metrica SetProfileCount (42) non corrispondente: %v", err)
+		t.Errorf("SetProfileCount metric mismatch for 42: %v", err)
 	}
 
-	// Testa l'aggiornamento del gauge
+	// Verify that the gauge can be updated.
 	SetProfileCount(10)
 	expectedUpdate := `
-		# HELP kapparmor_profiles_managed Numero totale di profili AppArmor attualmente gestiti.
+		# HELP kapparmor_profiles_managed Total number of AppArmor profiles currently managed.
 		# TYPE kapparmor_profiles_managed gauge
 		kapparmor_profiles_managed{node_name="` + testNodeName + `"} 10
 	`
 	if err := testutil.CollectAndCompare(currentProfiles, strings.NewReader(expectedUpdate), "kapparmor_profiles_managed"); err != nil {
-		t.Errorf("Metrica SetProfileCount (10) non corrispondente: %v", err)
+		t.Errorf("SetProfileCount metric mismatch for 10: %v", err)
 	}
 }
 
@@ -119,75 +101,73 @@ func TestProfileOperationsDoNotChangeManagedGauge(t *testing.T) {
 	testNodeName := getNodeNameFromEnv()
 
 	SetProfileCount(7)
-	ProfileCreated("profilo-a")
-	ProfileModified("profilo-b")
-	ProfileDeleted("profilo-c")
+	ProfileCreated("profile-a")
+	ProfileModified("profile-b")
+	ProfileDeleted("profile-c")
 
 	expected := `
-		# HELP kapparmor_profiles_managed Numero totale di profili AppArmor attualmente gestiti.
+		# HELP kapparmor_profiles_managed Total number of AppArmor profiles currently managed.
 		# TYPE kapparmor_profiles_managed gauge
 		kapparmor_profiles_managed{node_name="` + testNodeName + `"} 7
 	`
 	if err := testutil.CollectAndCompare(currentProfiles, strings.NewReader(expected), "kapparmor_profiles_managed"); err != nil {
-		t.Errorf("Metrica kapparmor_profiles_managed non corrispondente: %v", err)
+		t.Errorf("kapparmor_profiles_managed metric mismatch: %v", err)
 	}
 }
 
 func TestGetNodeNameFromEnv(t *testing.T) {
-	// 1. Test con NODE_NAME impostato
-	t.Setenv("NODE_NAME", "test-nodo-123")
+	// 1. Test with NODE_NAME explicitly set.
+	t.Setenv("NODE_NAME", "test-node-123")
 	name := getNodeNameFromEnv()
-	if name != "test-nodo-123" {
-		t.Errorf("Previsto 'test-nodo-123', ottenuto '%s'", name)
+	if name != "test-node-123" {
+		t.Errorf("expected 'test-node-123', got %q", name)
 	}
 
-	// 2. Test senza NODE_NAME (dovrebbe usare os.Hostname)
-	// Rimuove la variabile d'ambiente impostata da t.Setenv
-	t.Setenv("NODE_NAME", "") // Simula l'unset per questo sub-test
+	// 2. Without NODE_NAME the hostname should be used.
+	t.Setenv("NODE_NAME", "")
 
-	// Ricrea un test "pulito" per l'unset
 	t.Run("HostnameFallback", func(t *testing.T) {
-		t.Setenv("NODE_NAME", "") // Assicura che sia vuota
+		t.Setenv("NODE_NAME", "")
 		hostname, err := os.Hostname()
 		if err != nil {
-			t.Skipf("Impossible ottenere os.Hostname(): %v", err)
+			t.Skipf("unable to read os.Hostname(): %v", err)
 		}
 
 		name = getNodeNameFromEnv()
 		if name != hostname {
-			t.Errorf("Previsto hostname '%s', ottenuto '%s'", hostname, name)
+			t.Errorf("expected hostname %q, got %q", hostname, name)
 		}
 	})
 }
 
 func TestMetricsServerHandler(t *testing.T) {
-	// Non testiamo StartMetricsServer direttamente perché è bloccante e chiama log.Fatalf.
-	// Testiamo invece l'handler che registra, che è la parte logica cruciale.
+	// Do not test StartMetricsServer directly because it blocks and calls log.Fatalf.
+	// Test the HTTP handler instead, which contains the relevant behavior.
 	resetMetrics()
-	ProfileCreated("test-server-profilo")
+	ProfileCreated("test-server-profile")
 
-	// Crea una richiesta di test per /metrics
+	// Create a request for /metrics.
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rr := httptest.NewRecorder()
 
-	// Ottieni l'handler che StartMetricsServer userebbe
+	// Get the handler StartMetricsServer would use.
 	handler := promhttp.Handler()
 	handler.ServeHTTP(rr, req)
 
-	// Controlla lo status code
+	// Check the status code.
 	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("L'handler ha restituito uno status code errato: ottenuto %v, previsto %v",
+		t.Errorf("unexpected status code: got %v, want %v",
 			status, http.StatusOK)
 	}
 
-	// Controlla il body
+	// Check the response body.
 	body, _ := io.ReadAll(rr.Body)
 	bodyStr := string(body)
 
 	if !strings.Contains(bodyStr, "kapparmor_profile_operations_total") {
-		t.Error("Il body della risposta non contiene la metrica 'kapparmor_profile_operations_total'")
+		t.Error("response body does not contain kapparmor_profile_operations_total")
 	}
-	if !strings.Contains(bodyStr, `operation="create",profile_name="test-server-profilo"} 1`) {
-		t.Error("Il body della risposta non contiene il valore corretto per 'test-server-profilo'")
+	if !strings.Contains(bodyStr, `operation="create",profile_name="test-server-profile"} 1`) {
+		t.Error("response body does not contain the expected test-server-profile counter")
 	}
 }

--- a/src/app/profiles_ops.go
+++ b/src/app/profiles_ops.go
@@ -116,7 +116,7 @@ func calculateProfileChanges(cfg *AppConfig, newProfiles map[string]bool, custom
 			}
 			slog.Default().Info("Content changed, scheduling replacement", slog.String("name", newProfileName))
 			showProfilesDiff(cfg, newProfileName)
-			metrics.ProfileModified(newProfileName)
+			metrics.DefaultProfileMetrics().ProfileModified(newProfileName)
 		} else {
 			slog.Default().Info("New profile found, scheduling for load", slog.String("name", newProfileName))
 		}


### PR DESCRIPTION
## Summary
- introduce a `ProfileMetrics` owner for the managed-profile gauge and operation counters
- route the reconcile code through the owner object while preserving the gauge semantics introduced in #82
- translate the remaining Italian metrics package help text, comments, and test assertions to English

## Test plan
- [x] `make fmt`
- [x] `make vet lint test-coverage`
- [x] `go test -v -run 'TestLoadNewProfiles|TestProfileOperations|TestSetProfileCount|TestProfileOperationsDoNotChangeManagedGauge|TestMetricsServerHandler' ./src/app/...`

## Notes
- This PR is intentionally stacked on top of #82 so the refactor stays behavior-neutral.
- After #82 merges, this branch can be rebased or retargeted onto `main` with no intended metric-behavior changes.