### PR TITLE
ci(scorecard): pin action to release commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- re-pin `ossf/scorecard-action` in `.github/workflows/scorecard.yml` from the `v2.4.3` annotated tag object SHA to the verified `v2.4.3` commit SHA
- fix the current `main` Scorecard failure where the action rejects the tag-object pin during workflow verification as an imposter commit
- keep the change behaviorally minimal: same release version, corrected immutable commit reference

## Test plan
- [x] `make test`
- [x] parse `.github/workflows/scorecard.yml` locally with Ruby `YAML.load_file(...)`
- [x] verify the branch diff is limited to the single Scorecard pin line
- [ ] confirm the GitHub Actions `Scorecard supply-chain security` workflow passes on this PR