### PR TITLE
docs: refresh OpenSSF badge evidence

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,0 @@
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,6 @@ See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kappar
 
 ---
 
-## [0.1.9] - 2024-02-19
-
-See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/v0.1.9).
-
----
-
 ## [0.1.7] - 2025-05-07
 
 See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.1.7).
@@ -59,6 +53,12 @@ See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kappar
 ## [0.1.6] - 2024-07-17
 
 See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.1.6).
+
+---
+
+## [0.1.9] - 2024-02-19
+
+See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/v0.1.9).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.3.1] – 2025-11
+## [0.3.1] - 2025-11-22
 
 ### Added
 - Prometheus metrics integration (`kapparmor_profile_operations_total`, `kapparmor_profiles_managed`)
@@ -30,62 +30,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved MicroK8s restart detection in e2e tests
 - Two-phase Helm deployment with proper version validation
 
-### Fixed
-- No runtime vulnerabilities known at time of release
-
 ---
 
-## [0.3.0] – 2025-11-10
+## [0.3.0] - 2025-11-10
 
 See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.3.0).
 
-### Fixed
-- No runtime vulnerabilities known at time of release
+---
+
+## [0.2.1] - 2025-11-07
+
+See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.2.1).
 
 ---
 
-## [0.2.0] – 2024-02-19
+## [0.1.9] - 2024-02-19
 
-See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.2.0).
-
-### Fixed
-- No runtime vulnerabilities known at time of release
+See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/v0.1.9).
 
 ---
 
-## [0.1.5] – 2023-05-16
+## [0.1.7] - 2025-05-07
+
+See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.1.7).
+
+---
+
+## [0.1.6] - 2024-07-17
+
+See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.1.6).
+
+---
+
+## [0.1.5] - 2023-05-15
 
 See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.1.5).
 
-### Fixed
-- No runtime vulnerabilities known at time of release
-
 ---
 
-## [0.1.2] – 2023-02-16
+## [0.1.2] - 2023-02-16
 
 See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.1.2).
 
 ---
 
-## [0.1.1] – 2023-02-13
+## [0.1.1] - 2023-02-13
 
 See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.1.1).
 
 ---
 
-## [0.1.0] – 2023-02-01
+## [0.1.0] - 2023-02-01
 
 See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.1.0).
 
 ---
 
-## [0.0.6] – 2023-01-26
+## [0.0.6] - 2023-02-01
 
 Initial pre-release.
 
 ---
 
-## [0.0.5] – 2023-01-23
+## [0.0.5-alpha] - 2023-01-18
 
 See [GitHub release](https://github.com/tuxerrante/kapparmor/releases/tag/kapparmor-0.0.5-alpha).
+
+Security fixes are identified explicitly in release notes and GitHub Security
+Advisories when applicable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 ### Suggesting Features
 
-Open an issue labeled `enhancement`. Describe the use case and the value it brings.
+Open an [issue labeled `enhancement`](https://github.com/tuxerrante/kapparmor/issues/new?labels=enhancement).
+Describe the use case and the value it brings.
 
 ### Submitting Code Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 ### Suggesting Features
 
-Open a [GitHub Discussion](https://github.com/tuxerrante/kapparmor/discussions) or an issue labeled `enhancement`. Describe the use case and the value it brings.
+Open an issue labeled `enhancement`. Describe the use case and the value it brings.
 
 ### Submitting Code Changes
 
@@ -51,9 +51,9 @@ Open a [GitHub Discussion](https://github.com/tuxerrante/kapparmor/discussions) 
    ```bash
    make fmt vet lint test-coverage
    ```
-5. Commit with a signed commit (`git commit -s -S`) and a meaningful message.
+5. Commit with a meaningful message. Signed commits are encouraged.
 6. Push your branch and open a Pull Request against `main`.
-7. At least one maintainer review and approval is required before merging.
+7. Request maintainer review before merging.
 
 ---
 
@@ -101,7 +101,7 @@ See [docs/testing.md](docs/testing.md) for detailed testing instructions includi
 - **Error handling**: Always wrap errors with context; never silently discard errors.
 - **Security**: Follow OWASP Go best practices. Run `gosec` locally if in doubt.
 - **Documentation**: Public functions and types must have godoc comments.
-- **Commits**: Must be signed (`git config commit.gpgsign true`).
+- **Commits**: Signed commits are encouraged but are not currently enforced.
 
 ---
 
@@ -116,7 +116,7 @@ Every non-trivial change **must** include appropriate tests:
 | Refactoring | Existing tests must continue to pass |
 | Security fix | Test that demonstrates the vulnerability is fixed |
 
-- Minimum coverage target: **80%** (enforced via Codecov).
+- Coverage is measured in CI and reported through Codecov. Changes must not materially reduce coverage.
 - Test files use the `t_` name prefix (e.g., `t_myfeature_test.go`).
 - Fuzz tests are encouraged for functions that process external input.
 - Run `make test-coverage` to verify coverage locally.
@@ -129,7 +129,7 @@ Every non-trivial change **must** include appropriate tests:
 2. Ensure the CI pipeline passes (build, lint, test, security scan).
 3. Update documentation (`README.md`, `docs/`) if your change affects user-facing behaviour.
 4. Update `charts/kapparmor/CHANGELOG.md` for user-visible changes.
-5. PRs require **at least one approving review** from a maintainer.
+5. Obtain maintainer review before merging. Repository settings do not currently enforce a minimum approval count.
 6. Squash-merge or rebase-merge is preferred to keep a clean history.
 
 ---

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Kapparmor is built with security as a core principle:
 ✅ **Threat Modeling** – [Comprehensive STRIDE analysis](./docs/ThreatModel.md)
 ✅ **Code Quality** – Race-enabled unit tests, fuzzing, linting, and measured coverage
 ✅ **Supply Chain** – Pinned CI actions and automated dependency monitoring
-✅ **Vulnerability Scanning** – CodeQL, Gosec, and Trivy analysis
+✅ **Vulnerability Scanning** – CodeQL, Gosec, Trivy, and Snyk analysis
 ✅ **Least Privilege** – Scoped Kubernetes access with documented privileged host requirements
 
 👉 **[Read the full security threat model](./docs/ThreatModel.md)** for detailed analysis of risks and mitigations.

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ For security vulnerabilities, see [SECURITY.md](SECURITY.md).
 ## Community & Support
 
 - 🐛 **Found a bug?** [Open an issue](https://github.com/tuxerrante/kapparmor/issues)
-- 💡 **Feature request?** [Open an enhancement issue](https://github.com/tuxerrante/kapparmor/issues/new)
+- 💡 **Feature request?** [Open an enhancement issue](https://github.com/tuxerrante/kapparmor/issues/new?labels=enhancement)
 - 📚 **Need help?** Check the [docs](./docs)
 - 📋 **Changelog:** See [CHANGELOG.md](CHANGELOG.md) for release history
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ This work was inspired by [kubernetes/apparmor-loader](https://github.com/kubern
 🔐 **Enterprise-Grade Security**
 - Input validation with fuzz testing
 - Secure coding practices (SSDLC)
-- Supply chain security (signed commits, Harden-Runner, CodeQL)
-- Zero external runtime dependencies
+- Supply chain security (pinned CI actions, Harden-Runner, CodeQL)
+- Restricted dependency policy enforced by `depguard`
 
 ⚡ **Kubernetes-Native**
 - DaemonSet-based deployment
@@ -118,8 +118,8 @@ This work was inspired by [kubernetes/apparmor-loader](https://github.com/kubern
 📈 **Production-Ready**
 - Comprehensive test coverage
 - CI/CD security gates
-- OpenSSF Best Practices certified
-- No privileged escalation vectors
+- [OpenSSF Best Practices](https://www.bestpractices.dev/projects/8391) progress tracked publicly
+- Privileged host access documented in the [threat model](./docs/ThreatModel.md)
 
 ---
 
@@ -127,11 +127,11 @@ This work was inspired by [kubernetes/apparmor-loader](https://github.com/kubern
 
 Kapparmor is built with security as a core principle:
 
-✅ **Threat Modeling** – [Comprehensive STRIDE analysis](./docs/ThreatModel.md)  
-✅ **Code Quality** – 80%+ test coverage, zero high-severity CodeQL alerts  
-✅ **Supply Chain** – Pinned dependencies, signed commits, SBOM tracking  
-✅ **Vulnerability Scanning** – Trivy, Gosec, Snyk integration  
-✅ **Least Privilege** – Minimal RBAC, no elevated capabilities unless required  
+✅ **Threat Modeling** – [Comprehensive STRIDE analysis](./docs/ThreatModel.md)
+✅ **Code Quality** – Race-enabled unit tests, fuzzing, linting, and measured coverage
+✅ **Supply Chain** – Pinned CI actions and automated dependency monitoring
+✅ **Vulnerability Scanning** – CodeQL, Gosec, and Trivy analysis
+✅ **Least Privilege** – Scoped Kubernetes access with documented privileged host requirements
 
 👉 **[Read the full security threat model](./docs/ThreatModel.md)** for detailed analysis of risks and mitigations.
 
@@ -444,12 +444,12 @@ See the **[KAppArmor Demo project](https://github.com/tuxerrante/kapparmor-demo)
 2. ✏️ Update `charts/kapparmor/Chart.yaml` with matching version
 3. 🧪 Run unit and integration tests (see `Makefile`)
 4. ✏️ Update `charts/kapparmor/CHANGELOG.md`
-5. 📝 Open PR, get reviews
+5. 📝 Open a PR for maintainer review
 6. ✅ Merge to main
-7. 🏷️ Create signed Git tag: `git tag -s v1.0.0`
+7. 🏷️ Create a version tag
 8. 🚀 GitHub Actions automatically builds and publishes
 
-**Note:** Commits must be signed (`git config commit.gpgsign true`)
+Signed commits and tags are encouraged but are not currently enforced by repository settings.
 
 ---
 
@@ -470,7 +470,7 @@ For security vulnerabilities, see [SECURITY.md](SECURITY.md).
 ## Community & Support
 
 - 🐛 **Found a bug?** [Open an issue](https://github.com/tuxerrante/kapparmor/issues)
-- 💡 **Feature request?** [Start a discussion](https://github.com/tuxerrante/kapparmor/discussions)
+- 💡 **Feature request?** [Open an enhancement issue](https://github.com/tuxerrante/kapparmor/issues/new)
 - 📚 **Need help?** Check the [docs](./docs)
 - 📋 **Changelog:** See [CHANGELOG.md](CHANGELOG.md) for release history
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,8 +43,7 @@ We follow responsible disclosure: once a fix is published, the advisory will be 
 
 This project uses the following tools for ongoing vulnerability monitoring:
 
-- **Snyk** – automatic vulnerability detection and automated fix PRs
-- **Trivy** – container image scanning in CI (blocks on CRITICAL/HIGH findings)
+- **Trivy** – container image scanning in CI for CRITICAL/HIGH findings
 - **CodeQL** – static analysis in CI
 - **Dependabot** – weekly dependency update PRs
 - **Gosec** – Go security analysis in CI

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,7 @@ We follow responsible disclosure: once a fix is published, the advisory will be 
 
 This project uses the following tools for ongoing vulnerability monitoring:
 
+- **Snyk** – dependency analysis on pull requests
 - **Trivy** – container image scanning in CI for CRITICAL/HIGH findings
 - **CodeQL** – static analysis in CI
 - **Dependabot** – weekly dependency update PRs

--- a/docs/ThreatModel.md
+++ b/docs/ThreatModel.md
@@ -525,13 +525,12 @@ securityContext:
 **Status:** ✅ **ADDRESSED**
 
 **Controls:**
-1. Dependabot for Go modules (.github/dependabot.yaml)
-2. Trivy image scanning (build-app.yml)
+1. Dependabot for Go modules, Docker, and GitHub Actions (`.github/dependabot.yml`)
+2. Trivy image scanning (`.github/workflows/build-app.yml`)
 3. Go vulnerability scanning (`go vet`, `gosec` via golangci-lint)
-4. Pinned dependencies in go.mod
-5. SBOM generation (implicit via go.mod)
+4. Versioned Go dependencies in `go.mod`
 
-**Evidence:** Go Report Card badge shows "A+" rating
+**Gap:** Release SBOM generation and provenance attestations are not yet configured.
 
 ---
 
@@ -804,10 +803,10 @@ graph TD
 | **Code** | Input Validation | `isValidFilename`, `isSafePath` | ✅ |
 | **Code** | Static Analysis | CodeQL, golangci-lint | ✅ |
 | **Code** | Secrets Scanning | Gitleaks (pre-commit) | ✅ |
-| **Test** | Unit Tests | 43 test files, >80% coverage target | ✅ |
+| **Test** | Unit Tests | Race-enabled tests with coverage reporting | ✅ |
 | **Test** | Fuzz Testing | `FuzzIsProfileNameCorrect` | ✅ |
-| **Test** | Vulnerability Scanning | Gosec, Trivy, Snyk | ✅ |
-| **Build** | Signed Commits | GPG verification | ✅ |
+| **Test** | Vulnerability Scanning | Gosec, Trivy, CodeQL | ✅ |
+| **Build** | Signed Commits | Recommended; not enforced | ⚠️ |
 | **Build** | Hardened CI | Harden-Runner, egress audit | ✅ |
 | **Build** | Dependency Pinning | go.mod, image digests | ✅ |
 | **Deploy** | Image Signing | ⚠️ Missing (Cosign) | ❌ |
@@ -837,9 +836,9 @@ graph TD
 #### Dynamic Analysis (DAST)
 
 ⚠️ **Container Scanning** (Trivy)
-- Severity: `CRITICAL,HIGH` block builds
+- Severity: Reports `CRITICAL,HIGH` findings
 - Scan: OS packages only (not Go binaries)
-- Gap: Runtime behavior not tested
+- Gap: Findings are not yet configured to fail the workflow
 
 ❌ **Penetration Testing**
 - Not automated
@@ -850,11 +849,11 @@ graph TD
 ### 3. Supply Chain Security
 
 ✅ **OpenSSF Scorecard** (.github/workflows/scorecard.yml)
-- Badge: [8391](https://www.bestpractices.dev/projects/8391)
-- Checks: Branch protection, signed commits, pinned actions
+- Best Practices progress: [8391](https://www.bestpractices.dev/projects/8391)
+- Checks include branch protection, signed releases, and pinned dependencies
 
-✅ **Dependabot** (.github/dependabot.yaml)
-- Ecosystem: `gomod`
+✅ **Dependabot** (.github/dependabot.yml)
+- Ecosystems: `gomod`, Docker, and GitHub Actions
 - Frequency: Weekly
 - Auto-PR for updates
 
@@ -1163,10 +1162,10 @@ data:
 
 | Gate | Requirement | Status | Evidence |
 |------|-------------|--------|----------|
-| **Code Coverage** | >80% | ⚠️ Target (current: measure via Codecov) | [![codecov](https://codecov.io/gh/tuxerrante/kapparmor/branch/main/graph/badge.svg)](https://codecov.io/gh/tuxerrante/kapparmor) |
+| **Code Coverage** | Prevent material regression | ⚠️ Measured, threshold not enforced | [![codecov](https://codecov.io/gh/tuxerrante/kapparmor/branch/main/graph/badge.svg)](https://codecov.io/gh/tuxerrante/kapparmor) |
 | **Static Analysis** | Zero HIGH/CRITICAL | ✅ | CodeQL, golangci-lint pass |
-| **Vulnerability Scan** | Zero HIGH/CRITICAL | ✅ | Trivy blocks on findings |
-| **Signed Commits** | 100% | ✅ | `.git/config`: `commit.gpgsign = true` |
+| **Vulnerability Scan** | Report HIGH/CRITICAL | ⚠️ | Trivy reports findings but does not fail CI |
+| **Signed Commits** | Recommended | ⚠️ | Not enforced by repository settings |
 | **Dependency Updates** | Weekly | ✅ | Dependabot + cron |
 | **Secrets Detection** | Pre-commit | ✅ | Gitleaks hook |
 | **Dockerfile Security** | Best practices | ✅ | Hadolint, multi-stage, digest pins |
@@ -1294,9 +1293,9 @@ Kapparmor demonstrates **strong security posture** with 78% of identified threat
 ### Key Strengths
 1. Comprehensive input validation with fuzz testing
 2. Minimal attack surface through standard library usage
-3. Extensive CI/CD security gates (CodeQL, Trivy, Scorecard, Harden-Runner)
+3. CI/CD security analysis (CodeQL, Trivy, Scorecard, Harden-Runner)
 4. Defensive coding patterns (mutex locks, panic recovery, context cancellation)
-5. No external runtime dependencies
+5. Restricted, allowlisted runtime dependencies
 
 ### Critical Gaps
 1. **Resource exhaustion protection** (P1: Profile limits)
@@ -1316,7 +1315,7 @@ Kapparmor demonstrates **strong security posture** with 78% of identified threat
 - **Prepared By:** [@tuxerrante](https://github.com/tuxerrante) + Claude.ai
 - **Reviewed By:** [Pending]
 - **Approved By:** [Pending]
-- **Next Review:** Q2 2026 or upon major architecture change
+- **Next Review:** Q4 2026 or upon major architecture change
 
 ---
 

--- a/docs/ThreatModel.md
+++ b/docs/ThreatModel.md
@@ -805,7 +805,7 @@ graph TD
 | **Code** | Secrets Scanning | Gitleaks (pre-commit) | ✅ |
 | **Test** | Unit Tests | Race-enabled tests with coverage reporting | ✅ |
 | **Test** | Fuzz Testing | `FuzzIsProfileNameCorrect` | ✅ |
-| **Test** | Vulnerability Scanning | Gosec, Trivy, CodeQL | ✅ |
+| **Test** | Vulnerability Scanning | Gosec, Trivy, CodeQL, Snyk | ✅ |
 | **Build** | Signed Commits | Recommended; not enforced | ⚠️ |
 | **Build** | Hardened CI | Harden-Runner, egress audit | ✅ |
 | **Build** | Dependency Pinning | go.mod, image digests | ✅ |


### PR DESCRIPTION
## Summary

- align security, coverage, signing, and OpenSSF claims with controls currently enforced
- reconcile the root changelog with published GitHub releases
- remove the duplicate Dependabot configuration and update its references

## Validation

- `git diff --check`
- repository-wide stale-claim search
- pre-push self-review

## Follow-up

A separate PR will add enforceable Trivy and coverage gates before those controls are documented as blocking.